### PR TITLE
hotfix/add-pagination-support

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -3,10 +3,11 @@ import { Client } from './client'
 import { objectToSnake } from 'ts-case-convert'
 
 export class PostService extends Client {
-  async list(): Promise<PostResponse[]> {
+  async list(page: number): Promise<PostResponse[]> {
     const response = await this.get({
       url: '/post/',
-      needAuthorization: true
+      needAuthorization: true,
+      params: { page }
     })
     return response as unknown as PostResponse[]
   }


### PR DESCRIPTION
# Soporte para paginacion
Con la paginacion ya integrada en el backend se agrega el soporte para que retorne:
- `results`: resultados con los objetos
- `count`: numero total de objetos
- `next`: url con la siguiente pagina
- `previous`: url la pagina anterior